### PR TITLE
LoggerFactory slf4j related regression fix

### DIFF
--- a/h2o-logger/src/main/java/water/logging/LoggerFactory.java
+++ b/h2o-logger/src/main/java/water/logging/LoggerFactory.java
@@ -78,7 +78,7 @@ public class LoggerFactory {
         try {
             Class.forName(waterLogClassName);
             return true;
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
             return false;
         }
     }


### PR DESCRIPTION
Fix the regression that caused DRF loading fail due to spurious dependency on slf4j when log4j2 exists. Check for water logging availability was throwing exception if slf4j was not used while loading some models. this seems like a regression between 3.30 and 3.40. https://github.com/h2oai/h2o-3/issues/6725